### PR TITLE
#58 Add HasStyle and z-index

### DIFF
--- a/vaadin-maps-leaflet-flow/src/main/java/software/xdev/vaadin/maps/leaflet/flow/LMap.java
+++ b/vaadin-maps-leaflet-flow/src/main/java/software/xdev/vaadin/maps/leaflet/flow/LMap.java
@@ -30,6 +30,7 @@ import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.HasSize;
+import com.vaadin.flow.component.HasStyle;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
@@ -46,7 +47,7 @@ import software.xdev.vaadin.maps.leaflet.flow.data.LTileLayer;
 @NpmPackage(value = "leaflet", version = "^1.6.0")
 @Tag("leaflet-map")
 @JsModule("./leaflet/leafletCon.js")
-public class LMap extends Component implements HasSize
+public class LMap extends Component implements HasSize, HasStyle
 {
 
 	private static final String SET_VIEW_POINT_FUNCTION = "setViewPoint";
@@ -65,6 +66,7 @@ public class LMap extends Component implements HasSize
 		super();
 		this.center = new LCenter(lat, lon, zoom);
 		this.setViewPoint(this.center);
+		this.getStyle().set("z-index", "1");
 	}
 
 	public LMap()

--- a/vaadin-maps-leaflet-flow/src/main/java/software/xdev/vaadin/maps/leaflet/flow/LMap.java
+++ b/vaadin-maps-leaflet-flow/src/main/java/software/xdev/vaadin/maps/leaflet/flow/LMap.java
@@ -68,6 +68,7 @@ public class LMap extends Component implements HasSize, HasStyle
 		super();
 		this.center = new LCenter(lat, lon, zoom);
 		this.setViewPoint(this.center);
+		this.addClassName("leaflet-map");
 	}
 
 	public LMap()

--- a/vaadin-maps-leaflet-flow/src/main/java/software/xdev/vaadin/maps/leaflet/flow/LMap.java
+++ b/vaadin-maps-leaflet-flow/src/main/java/software/xdev/vaadin/maps/leaflet/flow/LMap.java
@@ -32,7 +32,6 @@ import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.HasStyle;
 import com.vaadin.flow.component.Tag;
-import com.vaadin.flow.component.dependency.CssImport;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.shared.Registration;
@@ -48,7 +47,6 @@ import software.xdev.vaadin.maps.leaflet.flow.data.LTileLayer;
 @NpmPackage(value = "leaflet", version = "^1.6.0")
 @Tag("leaflet-map")
 @JsModule("./leaflet/leafletCon.js")
-@CssImport(value = "./styles/LeafletMap.css")
 public class LMap extends Component implements HasSize, HasStyle
 {
 

--- a/vaadin-maps-leaflet-flow/src/main/java/software/xdev/vaadin/maps/leaflet/flow/LMap.java
+++ b/vaadin-maps-leaflet-flow/src/main/java/software/xdev/vaadin/maps/leaflet/flow/LMap.java
@@ -68,7 +68,7 @@ public class LMap extends Component implements HasSize, HasStyle
 		super();
 		this.center = new LCenter(lat, lon, zoom);
 		this.setViewPoint(this.center);
-		this.addClassName("leaflet-map");
+		this.setFixZIndexEnabled(true);
 	}
 
 	public LMap()
@@ -90,7 +90,18 @@ public class LMap extends Component implements HasSize, HasStyle
 	{
 		this.getElement().callJsFunction(TILE_LAYER_FUNCTION, tl.toJson());
 	}
-
+	
+	/**
+	 * This fixes situations where the leafletmap overlays components like Dialogs
+	 * 
+	 * @param enabled
+	 *            enable or disable the fix
+	 */
+	protected void setFixZIndexEnabled(final boolean enabled)
+	{
+		this.getStyle().set("z-index", enabled ? "1" : null);
+	}
+	
 	/**
 	 * add a Leaflet Component to the map.
 	 *

--- a/vaadin-maps-leaflet-flow/src/main/java/software/xdev/vaadin/maps/leaflet/flow/LMap.java
+++ b/vaadin-maps-leaflet-flow/src/main/java/software/xdev/vaadin/maps/leaflet/flow/LMap.java
@@ -32,6 +32,7 @@ import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.HasStyle;
 import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.dependency.CssImport;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.shared.Registration;
@@ -47,6 +48,7 @@ import software.xdev.vaadin.maps.leaflet.flow.data.LTileLayer;
 @NpmPackage(value = "leaflet", version = "^1.6.0")
 @Tag("leaflet-map")
 @JsModule("./leaflet/leafletCon.js")
+@CssImport(value = "./styles/LeafletMap.css")
 public class LMap extends Component implements HasSize, HasStyle
 {
 
@@ -66,7 +68,6 @@ public class LMap extends Component implements HasSize, HasStyle
 		super();
 		this.center = new LCenter(lat, lon, zoom);
 		this.setViewPoint(this.center);
-		this.getStyle().set("z-index", "1");
 	}
 
 	public LMap()

--- a/vaadin-maps-leaflet-flow/src/main/resources/META-INF/resources/frontend/styles/LeafletMap.css
+++ b/vaadin-maps-leaflet-flow/src/main/resources/META-INF/resources/frontend/styles/LeafletMap.css
@@ -1,4 +1,0 @@
-.leaflet-map
-{
-	z-index: 1;
-}

--- a/vaadin-maps-leaflet-flow/src/main/resources/META-INF/resources/frontend/styles/LeafletMap.css
+++ b/vaadin-maps-leaflet-flow/src/main/resources/META-INF/resources/frontend/styles/LeafletMap.css
@@ -1,4 +1,4 @@
-leaflet-map
+.leaflet-map
 {
 	z-index: 1;
 }

--- a/vaadin-maps-leaflet-flow/src/main/resources/META-INF/resources/frontend/styles/LeafletMap.css
+++ b/vaadin-maps-leaflet-flow/src/main/resources/META-INF/resources/frontend/styles/LeafletMap.css
@@ -1,0 +1,4 @@
+leaflet-map
+{
+	z-index: 1;
+}


### PR DESCRIPTION
Fixes #58 
Fixes #59 

This PR was originally only intended to cover issue #58, however ended up fixing #59 at the same time due to requirements of my solution. I've imported a CSS file into the LMap component, which includes a leaflet-map class. This class gets applied to every map within the constructor. This means that Vaadin dialogs will now show correctly in front of Leaflet map components. In a usecase where a custom z-index is required, it'll still allow you to remove the class or - alternatively - overwrite the z-index within the specified object.