### PR TITLE
Implement Leaflet Layer Control and Layer Groups

### DIFF
--- a/vaadin-maps-leaflet-flow/src/main/java/software/xdev/vaadin/maps/leaflet/flow/LMap.java
+++ b/vaadin-maps-leaflet-flow/src/main/java/software/xdev/vaadin/maps/leaflet/flow/LMap.java
@@ -47,6 +47,7 @@ import com.vaadin.flow.shared.Registration;
 
 import software.xdev.vaadin.maps.leaflet.flow.data.LCenter;
 import software.xdev.vaadin.maps.leaflet.flow.data.LComponent;
+import software.xdev.vaadin.maps.leaflet.flow.data.LLayerControl;
 import software.xdev.vaadin.maps.leaflet.flow.data.LTileLayer;
 
 
@@ -101,6 +102,19 @@ public class LMap extends Component implements HasSize, HasStyle, HasComponents
 			+ ");");
 	}
 	
+	public void setLayerControl(final LLayerControl layerControl)
+	{
+		try
+		{
+			final String addLayerControl = layerControl.buildClientJS() + "layerControl.addTo(" + CLIENT_MAP + ");";
+			this.getElement().executeJs(addLayerControl);
+		}
+		catch(JsonProcessingException e)
+		{
+			throw new RuntimeException(e);
+		}
+	}
+	
 	public void setTileLayer(final LTileLayer tl)
 	{
 		final String removeTileLayerIfPresent = "if (" + CLIENT_TILE_LAYER + ") {"
@@ -119,9 +133,8 @@ public class LMap extends Component implements HasSize, HasStyle, HasComponents
 	
 	/**
 	 * This fixes situations where the leafletmap overlays components like Dialogs
-	 * 
-	 * @param enabled
-	 *            enable or disable the fix
+	 *
+	 * @param enabled enable or disable the fix
 	 */
 	protected void setFixZIndexEnabled(final boolean enabled)
 	{

--- a/vaadin-maps-leaflet-flow/src/main/java/software/xdev/vaadin/maps/leaflet/flow/data/LLayerControl.java
+++ b/vaadin-maps-leaflet-flow/src/main/java/software/xdev/vaadin/maps/leaflet/flow/data/LLayerControl.java
@@ -1,0 +1,49 @@
+package software.xdev.vaadin.maps.leaflet.flow.data;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+
+public class LLayerControl
+{
+	private final LLayerControlOptions layerControlOptions;
+	private final Map<String, LComponent> overlays;
+	
+	public LLayerControl()
+	{
+		layerControlOptions = new LLayerControlOptions();
+		overlays = new HashMap<>();
+	}
+	
+	public void addOverlayLayer(String name, LComponent layer)
+	{
+		overlays.put(name, layer);
+	}
+	
+	public void addOverlayLayers(Map<String, LComponent> overlays)
+	{
+		this.overlays.putAll(overlays);
+	}
+	
+	public String buildClientJS() throws JsonProcessingException
+	{
+		
+		StringBuilder stringBuilder = new StringBuilder("let item = null;\nlet layerMap = {};\n");
+		
+		for(String name : overlays.keySet())
+		{
+			stringBuilder.append(overlays.get(name).buildClientJSItems().replaceFirst("let", ""));
+			stringBuilder.append("layerMap.push(\"").append(name).append("\": item);\n");
+		}
+		// TODO: add basemap support
+		stringBuilder.append("let layerControl = L.control.layers(null, layerMap, {\ncollapsed: ")
+			.append(layerControlOptions.isCollapsed())
+			.append(",\n hideSingleBase: ")
+			.append(layerControlOptions.isHideSingleBase())
+			.append("\n});\n");
+		//let layerControl = L.control.layers()
+		return stringBuilder.toString();
+	}
+}

--- a/vaadin-maps-leaflet-flow/src/main/java/software/xdev/vaadin/maps/leaflet/flow/data/LLayerControlOptions.java
+++ b/vaadin-maps-leaflet-flow/src/main/java/software/xdev/vaadin/maps/leaflet/flow/data/LLayerControlOptions.java
@@ -1,0 +1,27 @@
+package software.xdev.vaadin.maps.leaflet.flow.data;
+
+public class LLayerControlOptions
+{
+	private boolean collapsed = true;
+	private boolean hideSingleBase = false;
+	
+	public boolean isCollapsed()
+	{
+		return collapsed;
+	}
+	
+	public void setCollapsed(final boolean collapsed)
+	{
+		this.collapsed = collapsed;
+	}
+	
+	public boolean isHideSingleBase()
+	{
+		return hideSingleBase;
+	}
+	
+	public void setHideSingleBase(final boolean hideSingleBase)
+	{
+		this.hideSingleBase = hideSingleBase;
+	}
+}

--- a/vaadin-maps-leaflet-flow/src/main/java/software/xdev/vaadin/maps/leaflet/flow/data/LLayerGroup.java
+++ b/vaadin-maps-leaflet-flow/src/main/java/software/xdev/vaadin/maps/leaflet/flow/data/LLayerGroup.java
@@ -1,0 +1,56 @@
+package software.xdev.vaadin.maps.leaflet.flow.data;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import java.util.List;
+
+
+/**
+ * @author Evan Penner
+ * Layer group to bundle together multiple components
+ * @see LLayerControl
+ */
+public class LLayerGroup implements LComponent
+{
+	final List<LComponent> lComponents;
+	
+	/**
+	 * Create a new layer group.
+	 * @param lComponents the components to include in the layer group
+	 */
+	public LLayerGroup(final LComponent... lComponents)
+	{
+		this.lComponents = List.of(lComponents);
+	}
+	
+	@Override public String buildClientJSItems()
+	{
+		StringBuilder stringBuilder = new StringBuilder("let layers = [];\nlet item = null;\n");
+		
+		lComponents.forEach(lComponent -> {
+			try
+			{
+				// Work around for LComponent#buildClientJSItems() having "let"
+				stringBuilder.append(lComponent.buildClientJSItems().replaceFirst("let", ""))
+					.append("\nlayers.push(item);\n");
+			}
+			catch(JsonProcessingException e)
+			{
+				throw new RuntimeException(e);
+			}
+		});
+		
+		stringBuilder.append("item = L.layerGroup(layers);\n");
+		return stringBuilder.toString();
+	}
+	
+	/**
+	 * Does nothing
+	 *
+	 * @return empty string
+	 */
+	@Override public String getPopup()
+	{
+		return "";
+	}
+}

--- a/vaadin-maps-leaflet-flow/src/main/java/software/xdev/vaadin/maps/leaflet/flow/data/LLayerGroup.java
+++ b/vaadin-maps-leaflet-flow/src/main/java/software/xdev/vaadin/maps/leaflet/flow/data/LLayerGroup.java
@@ -25,7 +25,7 @@ public class LLayerGroup implements LComponent
 	
 	@Override public String buildClientJSItems()
 	{
-		StringBuilder stringBuilder = new StringBuilder("let layers = [];\nlet item = null;\n");
+		StringBuilder stringBuilder = new StringBuilder("let item = null;\nlet layers = [];\n");
 		
 		lComponents.forEach(lComponent -> {
 			try

--- a/vaadin-maps-leaflet-flow/src/main/java/software/xdev/vaadin/maps/leaflet/flow/data/LLayerGroup.java
+++ b/vaadin-maps-leaflet-flow/src/main/java/software/xdev/vaadin/maps/leaflet/flow/data/LLayerGroup.java
@@ -1,5 +1,7 @@
 package software.xdev.vaadin.maps.leaflet.flow.data;
 
+import static org.apache.commons.text.StringEscapeUtils.escapeEcmaScript;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 
 import java.util.List;
@@ -16,6 +18,7 @@ public class LLayerGroup implements LComponent
 	
 	/**
 	 * Create a new layer group.
+	 *
 	 * @param lComponents the components to include in the layer group
 	 */
 	public LLayerGroup(final LComponent... lComponents)
@@ -25,13 +28,16 @@ public class LLayerGroup implements LComponent
 	
 	@Override public String buildClientJSItems()
 	{
-		StringBuilder stringBuilder = new StringBuilder("let item = null;\nlet layers = [];\n");
+		StringBuilder stringBuilder = new StringBuilder("let item = null;\nvar layers = [];\n");
 		
 		lComponents.forEach(lComponent -> {
 			try
 			{
 				// Work around for LComponent#buildClientJSItems() having "let"
 				stringBuilder.append(lComponent.buildClientJSItems().replaceFirst("let", ""))
+					.append((lComponent.getPopup() != null
+						? "item.bindPopup('" + escapeEcmaScript(lComponent.getPopup()) + "');\n"
+						: ""))
 					.append("\nlayers.push(item);\n");
 			}
 			catch(JsonProcessingException e)
@@ -51,6 +57,6 @@ public class LLayerGroup implements LComponent
 	 */
 	@Override public String getPopup()
 	{
-		return "";
+		return null;
 	}
 }


### PR DESCRIPTION
I added in leaflet basic layer control and groups. For now, it only has overlay support. I did so in a way as to not tamper with the other classes. To make the implementation seamless would require a large rewrite of the way LComponents are registered. I figured I would leave that up to you maintainers to decide.
![image](https://user-images.githubusercontent.com/9202763/197360926-f81224c2-719e-45ac-bf6e-f925bcbfe3e3.png)
