### PR TITLE
 Add support for Leaflet.markercluster

### DIFF
--- a/vaadin-maps-leaflet-flow-demo/frontend/styles/cluster-state.css
+++ b/vaadin-maps-leaflet-flow-demo/frontend/styles/cluster-state.css
@@ -1,0 +1,14 @@
+
+.cluster-ok {
+    background-color: rgba(181, 226, 140, 0.6);
+}
+.cluster-ok div {
+    background-color: rgba(110, 204, 57, 0.6);
+}
+
+.cluster-nok {
+    background-color: rgba(253, 156, 115, 0.6);
+}
+.cluster-nok div {
+    background-color: rgba(241, 128, 23, 0.6);
+}

--- a/vaadin-maps-leaflet-flow-demo/src/main/java/software/xdev/vaadin/maps/leaflet/flow/demo/LeafletView.java
+++ b/vaadin-maps-leaflet-flow-demo/src/main/java/software/xdev/vaadin/maps/leaflet/flow/demo/LeafletView.java
@@ -105,6 +105,7 @@ public class LeafletView extends VerticalLayout
 	{
 		this.markerZob = new LMarker(49.673470, 12.160108, "ZoB");
 		this.markerZob.setPopup("Central bus station");
+		this.markerZob.setToolip("Alert state=true");
 		this.markerZob.setAlertState(true); //Cluster will be red once it includes this Marker upon zoom-out
 		
 		

--- a/vaadin-maps-leaflet-flow-demo/src/main/java/software/xdev/vaadin/maps/leaflet/flow/demo/LeafletView.java
+++ b/vaadin-maps-leaflet-flow-demo/src/main/java/software/xdev/vaadin/maps/leaflet/flow/demo/LeafletView.java
@@ -122,7 +122,7 @@ public class LeafletView extends VerticalLayout
 		xDevLogo.setIconSize(100, 20);
 		xDevLogo.setIconAnchor(50, 0);
 		markerXDev.setPopup("<a href='https://xdev.software/en' target='" + AnchorTarget.BLANK.getValue() + "'>XDEV Software GmbH</a>");
-		markerXDev.setIcon(xDevLogo);
+		//markerXDev.setIcon(xDevLogo);
 		
 		final LMarker markerInfo = new LMarker(49.674095, 12.162257);
 		final LDivIcon div = new LDivIcon(
@@ -174,10 +174,11 @@ public class LeafletView extends VerticalLayout
 		this.map.addMarkerClickListener(ev -> System.out.println(ev.getTag()));
 		
 		this.map.addLComponents(
-			markerXDev,
-			markerInfo,
+			//markerXDev,
+			//markerInfo,
 			this.markerZob,
-			polygonNoc,
+			//polygonNoc,
 			this.markerRathaus);
+		this.map.addMarkerCluster();
 	}
 }

--- a/vaadin-maps-leaflet-flow-demo/src/main/java/software/xdev/vaadin/maps/leaflet/flow/demo/LeafletView.java
+++ b/vaadin-maps-leaflet-flow-demo/src/main/java/software/xdev/vaadin/maps/leaflet/flow/demo/LeafletView.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import com.vaadin.flow.component.ClickEvent;
 import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.dependency.CssImport;
 import com.vaadin.flow.component.dialog.Dialog;
 import com.vaadin.flow.component.html.AnchorTarget;
 import com.vaadin.flow.component.icon.Icon;
@@ -27,6 +28,7 @@ import software.xdev.vaadin.maps.leaflet.flow.data.LTileLayer;
 
 
 @Route("")
+@CssImport("./styles/cluster-state.css")
 public class LeafletView extends VerticalLayout
 {
 	private boolean viewLunch = false;
@@ -103,6 +105,8 @@ public class LeafletView extends VerticalLayout
 	{
 		this.markerZob = new LMarker(49.673470, 12.160108, "ZoB");
 		this.markerZob.setPopup("Central bus station");
+		this.markerZob.setAlertState(true); //Cluster will be red once it includes this Marker upon zoom-out
+		
 		
 		final LMarker markerXDev = new LMarker(49.675806677512824, 12.160990185846394);
 		final LIcon xDevLogo = new LIcon(
@@ -168,7 +172,7 @@ public class LeafletView extends VerticalLayout
 		
 		this.map = new LMap(49.675126, 12.160733, 17);
 		this.map.setTileLayer(LTileLayer.DEFAULT_OPENSTREETMAP_TILE);
-		this.map.enableMarkerCluster();
+		this.map.enableMarkerCluster(true);
 		
 		this.map.setSizeFull();
 		// add some logic here for called Markers (token)

--- a/vaadin-maps-leaflet-flow-demo/src/main/java/software/xdev/vaadin/maps/leaflet/flow/demo/LeafletView.java
+++ b/vaadin-maps-leaflet-flow-demo/src/main/java/software/xdev/vaadin/maps/leaflet/flow/demo/LeafletView.java
@@ -122,7 +122,7 @@ public class LeafletView extends VerticalLayout
 		xDevLogo.setIconSize(100, 20);
 		xDevLogo.setIconAnchor(50, 0);
 		markerXDev.setPopup("<a href='https://xdev.software/en' target='" + AnchorTarget.BLANK.getValue() + "'>XDEV Software GmbH</a>");
-		//markerXDev.setIcon(xDevLogo);
+		markerXDev.setIcon(xDevLogo);
 		
 		final LMarker markerInfo = new LMarker(49.674095, 12.162257);
 		final LDivIcon div = new LDivIcon(
@@ -175,10 +175,10 @@ public class LeafletView extends VerticalLayout
 		this.map.addMarkerClickListener(ev -> System.out.println(ev.getTag()));
 		
 		this.map.addLComponents(
-			//markerXDev,
-			//markerInfo,
+			markerXDev,
+			markerInfo,
 			this.markerZob,
-			//polygonNoc,
+			polygonNoc,
 			this.markerRathaus);
 		this.map.addMarkerCluster();
 	}

--- a/vaadin-maps-leaflet-flow-demo/src/main/java/software/xdev/vaadin/maps/leaflet/flow/demo/LeafletView.java
+++ b/vaadin-maps-leaflet-flow-demo/src/main/java/software/xdev/vaadin/maps/leaflet/flow/demo/LeafletView.java
@@ -168,6 +168,7 @@ public class LeafletView extends VerticalLayout
 		
 		this.map = new LMap(49.675126, 12.160733, 17);
 		this.map.setTileLayer(LTileLayer.DEFAULT_OPENSTREETMAP_TILE);
+		this.map.enableMarkerCluster();
 		
 		this.map.setSizeFull();
 		// add some logic here for called Markers (token)

--- a/vaadin-maps-leaflet-flow/src/main/java/software/xdev/vaadin/maps/leaflet/flow/LMap.java
+++ b/vaadin-maps-leaflet-flow/src/main/java/software/xdev/vaadin/maps/leaflet/flow/LMap.java
@@ -69,6 +69,7 @@ public class LMap extends Component implements HasSize, HasStyle, HasComponents
 	private LCenter center;
 	private final List<LComponent> components = new ArrayList<>();
 	private boolean clusterEnabled = false;
+	private boolean clusterLayerAdded = false;
 	
 	public LMap()
 	{
@@ -150,9 +151,14 @@ public class LMap extends Component implements HasSize, HasStyle, HasComponents
 	 * @return true if clustering has been enabled, false if enableMarkerCluster has not been called prior to this call
 	 */
 	public boolean addMarkerCluster() {
-		if (this.clusterEnabled)
-			this.getElement().executeJs(CLIENT_MAP + ".addLayer("+CLIENT_CLUSTER_LAYER+");");
-		return clusterEnabled;
+		boolean added = false;
+		if (this.clusterEnabled && !this.clusterLayerAdded)
+		{
+			this.getElement().executeJs(CLIENT_MAP + ".addLayer(" + CLIENT_CLUSTER_LAYER + ");");
+			this.clusterLayerAdded = true;
+			added = true;
+		}
+		return added;
 	}
 	
 	/**

--- a/vaadin-maps-leaflet-flow/src/main/java/software/xdev/vaadin/maps/leaflet/flow/LMap.java
+++ b/vaadin-maps-leaflet-flow/src/main/java/software/xdev/vaadin/maps/leaflet/flow/LMap.java
@@ -117,16 +117,38 @@ public class LMap extends Component implements HasSize, HasStyle, HasComponents
 			+ ");");
 	}
 	
-	public void enableMarkerCluster()
+	/**
+	 * Creates the MarkerClusterGroup layer to enable clustering LMarkers clustering
+	 * @param showAlerts : if true, Cluster color will depend on the alert state of its LMarkers (defined by custom CSS) if false, default MarkerCluster css is used
+	 */
+	public void enableMarkerCluster(boolean showAlerts)
 	{
 		if(!this.clusterEnabled)
 		{
-			this.getElement().executeJs(CLIENT_CLUSTER_LAYER + "="
-				+ "L.markerClusterGroup();");
+			if(showAlerts)
+			{
+				this.getElement().executeJs(CLIENT_CLUSTER_LAYER + "="
+					+ "L.markerClusterGroup({iconCreateFunction: function(cluster) {\n"
+					+ "let markers = cluster.getAllChildMarkers();\n"
+					+ "let cname = 'cluster-ok';\n"
+					+ "for (var i = 0; i< markers.length; i++) {\n"
+					+ "if (markers[i].options.alert_state) {\n"
+					+ "cname = 'cluster-nok';\nbreak;\n}\n"
+					+ "}\n"
+					+ "return new L.DivIcon({ html: '<div><span>' + cluster.getChildCount() + '</span></div>', "
+					+ "className: 'marker-cluster ' + cname, iconSize: new L.Point(40, 40) });"
+					+ "}});");
+			} else {
+				this.getElement().executeJs(CLIENT_CLUSTER_LAYER +  " = L.markerClusterGroup();");
+			}
 			this.clusterEnabled = true;
 		}
 	}
-
+	
+	/**
+	 * Once all LMarkers have been added to the map, adds the MarkerCluster and enable clustering
+	 * @return true if clustering has been enabled, false if enableMarkerCluster has not been called prior to this call
+	 */
 	public boolean addMarkerCluster() {
 		if (this.clusterEnabled)
 			this.getElement().executeJs(CLIENT_MAP + ".addLayer("+CLIENT_CLUSTER_LAYER+");");

--- a/vaadin-maps-leaflet-flow/src/main/java/software/xdev/vaadin/maps/leaflet/flow/LMap.java
+++ b/vaadin-maps-leaflet-flow/src/main/java/software/xdev/vaadin/maps/leaflet/flow/LMap.java
@@ -162,6 +162,22 @@ public class LMap extends Component implements HasSize, HasStyle, HasComponents
 	}
 	
 	/**
+	 * Removes the MarkerCluster Layer from the map, disabling clustering
+	 * @return true if layer removed, false otherwise
+	 */
+	public boolean removeMarkerCluster() {
+		boolean removed = false;
+		if (this.clusterLayerAdded)
+		{
+			this.getElement().executeJs(CLIENT_MAP + ".removeLayer(" + CLIENT_CLUSTER_LAYER + ");");
+			this.clusterLayerAdded = false;
+			this.clusterEnabled = false;
+			removed = true;
+		}
+		return removed;
+	}
+	
+	/**
 	 * Uses fitBounds https://leafletjs.com/reference.html#map-fitbounds
 	 * to compute zoom level and center coordinates to zoom the map on the given rectangle
 	 * @param noPoint : Top let point on the map

--- a/vaadin-maps-leaflet-flow/src/main/java/software/xdev/vaadin/maps/leaflet/flow/LMap.java
+++ b/vaadin-maps-leaflet-flow/src/main/java/software/xdev/vaadin/maps/leaflet/flow/LMap.java
@@ -242,6 +242,11 @@ public class LMap extends Component implements HasSize, HasStyle, HasComponents
 				sb.append(escapeEcmaScript(lComponent.getPopup()));
 				sb.append("');\n");
 			}
+			if (lComponent.getTooltip() != null) {
+				sb.append("item.bindTooltip('");
+				sb.append(escapeEcmaScript(lComponent.getTooltip()));
+				sb.append("');\n");
+			}
 			sb.append(CLIENT_COMPONENTS);
 			sb.append(".push(item);");
 			this.getElement().executeJs(sb.toString());

--- a/vaadin-maps-leaflet-flow/src/main/java/software/xdev/vaadin/maps/leaflet/flow/LMap.java
+++ b/vaadin-maps-leaflet-flow/src/main/java/software/xdev/vaadin/maps/leaflet/flow/LMap.java
@@ -44,6 +44,7 @@ import com.vaadin.flow.shared.Registration;
 
 import software.xdev.vaadin.maps.leaflet.flow.data.LCenter;
 import software.xdev.vaadin.maps.leaflet.flow.data.LComponent;
+import software.xdev.vaadin.maps.leaflet.flow.data.LMarker;
 import software.xdev.vaadin.maps.leaflet.flow.data.LPoint;
 import software.xdev.vaadin.maps.leaflet.flow.data.LTileLayer;
 
@@ -199,7 +200,7 @@ public class LMap extends Component implements HasSize, HasStyle, HasComponents
 		{
 			final StringBuilder sb = new StringBuilder(lComponent.buildClientJSItems());
 			sb.append("\n");
-			if (this.clusterEnabled)
+			if (this.clusterEnabled && (lComponent instanceof LMarker))
 			{
 				sb.append(CLIENT_CLUSTER_LAYER);
 				sb.append(".addLayer(item);\n");

--- a/vaadin-maps-leaflet-flow/src/main/java/software/xdev/vaadin/maps/leaflet/flow/data/LCircle.java
+++ b/vaadin-maps-leaflet-flow/src/main/java/software/xdev/vaadin/maps/leaflet/flow/data/LCircle.java
@@ -236,6 +236,22 @@ public class LCircle implements LComponent
 		this.properties.setPopup(popup);
 	}
 	
+	@Override
+	public String getTooltip()
+	{
+		return this.properties.getTooltip();
+	}
+	
+	/**
+	 * Sets a Tooltip to the Marker
+	 *
+	 * @param toolip
+	 */
+	public void setToolip(final String toolip)
+	{
+		this.properties.setTooltip(toolip);
+	}
+	
 	public String getFillRule()
 	{
 		return this.properties.getFillRule();

--- a/vaadin-maps-leaflet-flow/src/main/java/software/xdev/vaadin/maps/leaflet/flow/data/LComponent.java
+++ b/vaadin-maps-leaflet-flow/src/main/java/software/xdev/vaadin/maps/leaflet/flow/data/LComponent.java
@@ -31,4 +31,5 @@ public interface LComponent
 	String buildClientJSItems() throws JsonProcessingException;
 	
 	String getPopup();
+	String getTooltip();
 }

--- a/vaadin-maps-leaflet-flow/src/main/java/software/xdev/vaadin/maps/leaflet/flow/data/LMarker.java
+++ b/vaadin-maps-leaflet-flow/src/main/java/software/xdev/vaadin/maps/leaflet/flow/data/LMarker.java
@@ -126,6 +126,22 @@ public class LMarker implements LComponent
 		this.properties.setPopup(popup);
 	}
 	
+	@Override
+	public String getTooltip()
+	{
+		return this.properties.getTooltip();
+	}
+	
+	/**
+	 * Sets a Tooltip to the Marker
+	 *
+	 * @param toolip
+	 */
+	public void setToolip(final String toolip)
+	{
+		this.properties.setTooltip(toolip);
+	}
+	
 	public String getTag()
 	{
 		return this.tag;

--- a/vaadin-maps-leaflet-flow/src/main/java/software/xdev/vaadin/maps/leaflet/flow/data/LMarker.java
+++ b/vaadin-maps-leaflet-flow/src/main/java/software/xdev/vaadin/maps/leaflet/flow/data/LMarker.java
@@ -136,6 +136,22 @@ public class LMarker implements LComponent
 		this.tag = tag;
 	}
 	
+	/**
+	 * Sets this LMarkers alert state to be used when alertMode has been enabled on MarkerCluster.
+	 * This needs to be called prior to adding the component to the map
+	 * @param state
+	 */
+	public void setAlertState(boolean state) {
+		this.properties.setAlertState(state);
+	}
+	
+	/**
+	 * @return Marker's alert state
+	 */
+	public boolean getAlertState() {
+		return this.properties.getAlertState();
+	}
+	
 	@Override
 	public String buildClientJSItems() throws JsonProcessingException
 	{
@@ -148,6 +164,7 @@ public class LMarker implements LComponent
 			+ "(" + mapper.writeValueAsString(this.properties.getIcon()) + ")"
 			+ " }"
 			+ ");"
+			+ "item.options.alert_state="+this.properties.getAlertState()+";"
 			+ (this.getTag() != null && !this.getTag().isBlank()
 			? ("\nvar vaadinServer = this.$server;"
 			+ "\nitem.on('click', function (e) { vaadinServer.onMarkerClick('" + this.tag + "') });")

--- a/vaadin-maps-leaflet-flow/src/main/java/software/xdev/vaadin/maps/leaflet/flow/data/LMarkerOptions.java
+++ b/vaadin-maps-leaflet-flow/src/main/java/software/xdev/vaadin/maps/leaflet/flow/data/LMarkerOptions.java
@@ -21,6 +21,7 @@ public class LMarkerOptions
 {
 	private String popup;
 	private LIcon icon;
+	private boolean alertState = false;
 	
 	public LMarkerOptions()
 	{
@@ -45,5 +46,13 @@ public class LMarkerOptions
 	public void setPopup(final String popup)
 	{
 		this.popup = popup;
+	}
+	
+	public void setAlertState(boolean state) {
+		this.alertState = state;
+	}
+	
+	public boolean getAlertState() {
+		return this.alertState;
 	}
 }

--- a/vaadin-maps-leaflet-flow/src/main/java/software/xdev/vaadin/maps/leaflet/flow/data/LMarkerOptions.java
+++ b/vaadin-maps-leaflet-flow/src/main/java/software/xdev/vaadin/maps/leaflet/flow/data/LMarkerOptions.java
@@ -20,6 +20,7 @@ package software.xdev.vaadin.maps.leaflet.flow.data;
 public class LMarkerOptions
 {
 	private String popup;
+	private String tooltip;
 	private LIcon icon;
 	private boolean alertState = false;
 	
@@ -46,6 +47,16 @@ public class LMarkerOptions
 	public void setPopup(final String popup)
 	{
 		this.popup = popup;
+	}
+	
+	public String getTooltip()
+	{
+		return this.tooltip;
+	}
+	
+	public void setTooltip(final String tooltip)
+	{
+		this.tooltip = tooltip;
 	}
 	
 	public void setAlertState(boolean state) {

--- a/vaadin-maps-leaflet-flow/src/main/java/software/xdev/vaadin/maps/leaflet/flow/data/LPolygon.java
+++ b/vaadin-maps-leaflet-flow/src/main/java/software/xdev/vaadin/maps/leaflet/flow/data/LPolygon.java
@@ -231,6 +231,22 @@ public class LPolygon implements LComponent
 		this.properties.setPopup(popup);
 	}
 	
+	@Override
+	public String getTooltip()
+	{
+		return this.properties.getTooltip();
+	}
+	
+	/**
+	 * Sets a Tooltip to the Marker
+	 *
+	 * @param toolip
+	 */
+	public void setToolip(final String toolip)
+	{
+		this.properties.setTooltip(toolip);
+	}
+	
 	public String getFillRule()
 	{
 		return this.properties.getFillRule();

--- a/vaadin-maps-leaflet-flow/src/main/java/software/xdev/vaadin/maps/leaflet/flow/data/LPolygonOptions.java
+++ b/vaadin-maps-leaflet-flow/src/main/java/software/xdev/vaadin/maps/leaflet/flow/data/LPolygonOptions.java
@@ -39,6 +39,8 @@ public class LPolygonOptions
 	private double radius;
 	
 	private String popup;
+	private String tooltip;
+	
 	
 	public double getRadius()
 	{
@@ -195,4 +197,14 @@ public class LPolygonOptions
 		this.popup = popup;
 	}
 	
+	
+	public String getTooltip()
+	{
+		return this.tooltip;
+	}
+	
+	public void setTooltip(final String tooltip)
+	{
+		this.tooltip = tooltip;
+	}
 }


### PR DESCRIPTION
These changes add basic support for [Leaflet.markercluster](https://github.com/Leaflet/Leaflet.markercluster).
It enabled Markers clustering and adds an option to customize the cluster's color based on the state of the markers it contains (for example to show that at least one marker is in Error state).
It also adds the API needed to add Tooltips to the Markers.