### PR TITLE
refactor: upgrade to v25

### DIFF
--- a/flow-demo/pom.xml
+++ b/flow-demo/pom.xml
@@ -20,7 +20,7 @@
 	</organization>
 
 	<properties>
-		<javaVersion>17</javaVersion>
+		<javaVersion>21</javaVersion>
 		<maven.compiler.release>${javaVersion}</maven.compiler.release>
 
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -29,9 +29,9 @@
 		<mainClass>software.xdev.vaadin.Application</mainClass>
 
 		<!-- Dependency-Versions -->
-		<vaadin.version>24.9.2</vaadin.version>
+		<vaadin.version>25.0.0-beta1</vaadin.version>
 
-		<org.springframework.boot.version>3.5.6</org.springframework.boot.version>
+		<org.springframework.boot.version>4.0.0-M3</org.springframework.boot.version>
 	</properties>
 
 	<dependencyManagement>

--- a/flow-demo/src/main/java/software/xdev/vaadin/Application.java
+++ b/flow-demo/src/main/java/software/xdev/vaadin/Application.java
@@ -4,15 +4,18 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
 
+import com.vaadin.flow.component.dependency.StyleSheet;
 import com.vaadin.flow.component.page.AppShellConfigurator;
 import com.vaadin.flow.component.page.Push;
 import com.vaadin.flow.spring.annotation.EnableVaadin;
+import com.vaadin.flow.theme.lumo.Lumo;
 
 
 @SuppressWarnings({"checkstyle:HideUtilityClassConstructor", "PMD.UseUtilityClass"})
 @SpringBootApplication
 @EnableVaadin
 @Push
+@StyleSheet(Lumo.STYLESHEET)
 public class Application extends SpringBootServletInitializer implements AppShellConfigurator
 {
 	public static void main(final String[] args)

--- a/flow-demo/src/main/java/software/xdev/vaadin/maps/leaflet/flow/demo/ComplexDemo.java
+++ b/flow-demo/src/main/java/software/xdev/vaadin/maps/leaflet/flow/demo/ComplexDemo.java
@@ -15,8 +15,6 @@ import com.vaadin.flow.component.notification.Notification;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.router.Route;
 
-import elemental.json.JsonObject;
-import elemental.json.JsonValue;
 import software.xdev.vaadin.maps.leaflet.MapContainer;
 import software.xdev.vaadin.maps.leaflet.basictypes.LDivIcon;
 import software.xdev.vaadin.maps.leaflet.basictypes.LDivIconOptions;
@@ -46,6 +44,9 @@ import software.xdev.vaadin.maps.leaflet.layer.vector.LPolyline;
 import software.xdev.vaadin.maps.leaflet.map.LMap;
 import software.xdev.vaadin.maps.leaflet.map.LMapLocateOptions;
 import software.xdev.vaadin.maps.leaflet.registry.LDefaultComponentManagementRegistry;
+
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ObjectNode;
 
 
 @Route(ComplexDemo.NAV)
@@ -258,14 +259,14 @@ public class ComplexDemo extends AbstractDemo
 	
 	// This server side method will be called when the map is clicked
 	@ClientCallable
-	public void mapClicked(final JsonValue input)
+	public void mapClicked(final JsonNode input)
 	{
-		if(!(input instanceof final JsonObject obj))
+		if(!(input instanceof final ObjectNode obj))
 		{
 			return;
 		}
 		
-		LOG.info("Map clicked - lat: {}, lng: {}", obj.getNumber("lat"), obj.getNumber("lng"));
+		LOG.info("Map clicked - lat: {}, lng: {}", obj.get("lat").asDouble(), obj.get("lng").asDouble());
 	}
 	
 	private void addLocateDemo()
@@ -404,7 +405,7 @@ public class ComplexDemo extends AbstractDemo
 			new Button(
 				"Get bounds",
 				ev -> this.map.invokeSelfReturn(".getBounds()")
-					.then(v -> Notification.show(v.toJson())))
+					.then(v -> Notification.show(v.toString())))
 		);
 	}
 	

--- a/flow/pom.xml
+++ b/flow/pom.xml
@@ -42,14 +42,14 @@
 	</licenses>
 
 	<properties>
-		<javaVersion>17</javaVersion>
+		<javaVersion>21</javaVersion>
 		<maven.compiler.release>${javaVersion}</maven.compiler.release>
 
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
 		<!-- Dependency-Versions -->
-		<vaadin.version>24.9.2</vaadin.version>
+		<vaadin.version>25.0.0-beta1</vaadin.version>
 	</properties>
 
 	<dependencyManagement>

--- a/flow/src/main/java/software/xdev/vaadin/maps/leaflet/registry/LDefaultComponentManagementRegistry.java
+++ b/flow/src/main/java/software/xdev/vaadin/maps/leaflet/registry/LDefaultComponentManagementRegistry.java
@@ -125,7 +125,7 @@ public class LDefaultComponentManagementRegistry extends Composite<Div> implemen
 		this.getElement()
 			.executeJs(
 				this.clientComponents() + ".set(" + currentId + ", " + jsConstructorCallExpression + ");",
-				parameters);
+				(Object[]) parameters);
 		this.clientMapSize.incrementAndGet();
 		this.componentIndexMap.put(component, currentId);
 		
@@ -143,7 +143,7 @@ public class LDefaultComponentManagementRegistry extends Composite<Div> implemen
 	@Override
 	public PendingJavaScriptResult execJs(final String js, final Serializable... params)
 	{
-		return this.getElement().executeJs(js, params);
+		return this.getElement().executeJs(js, (Object[]) params);
 	}
 	
 	@Override


### PR DESCRIPTION
I'm currently looking through several Vaadin add-ons to check for potential issues with the upcoming Vaadin 25. This add-on seems to work well with some minor tweaks, I've compiled my results in this PR:
- Replace usage of deprecated `executeJs` API
- Update demo to load Lumo theme, which is not loaded by default anymore
- Update demo to handle breaking changes from moving to Jackson 3 for RPC calls

When you're ready to proceed with upgrading, feel free to update to this PR or use the changes in your own PR. Thanks!